### PR TITLE
Add option for verbosity level.

### DIFF
--- a/ext/wit/wit.c
+++ b/ext/wit/wit.c
@@ -7,13 +7,22 @@ static VALUE rb_cb;
 
 static VALUE libwit_init(int argc, VALUE *argv, VALUE obj) {
 	const char *device_opt = NULL;
+	unsigned int verbosity = 4;
 	VALUE device = Qnil;
-	rb_scan_args(argc, argv, "01", &device);
+	VALUE verbosity_level = Qnil;
+	rb_scan_args(argc, argv, "02", &device, &verbosity_level);
+
 	if (device != Qnil) {
 		Check_Type(device, T_STRING);
 		device_opt = StringValuePtr(device);
 	}
-	context = wit_init(device_opt, 4);
+
+	if (verbosity_level != Qnil) {
+		Check_Type(verbosity_level, T_FIXNUM);
+		verbosity = NUM2UINT(verbosity_level);
+	}
+
+	context = wit_init(device_opt, verbosity);
 	return Qnil;
 }
 


### PR DESCRIPTION
wit-ai/libwit#1 added a verbosity argument to libwit, but libwit-ruby unconditionally sets this value to 4, the highest possible level.

This PR adds an optional supplemental argument to `Wit#init` that lets users specify their desired log level:

``` ruby
# The `nil` is to use the default device_opt, the `0` tells Wit not to log at all
Wit.init(nil, 0)
```

I haven't put any documentation in because I'm not sure where that would go here.
