### PR TITLE
Add Gemfile with gemspec directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gem
 *.swo
 *.swp
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gemspec


### PR DESCRIPTION
This allows a developer to use `bundle` to install dependencies and ensure that their system is ready to run relevant Ruby commands. This is also convention as an installation step for most CI services.

`Gemfile.lock` has also been ignored, as this has no effect for users of the library installing via Rubygems. See http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/ for more information.
