### PR TITLE
Add configurable logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ gem install wit-*.gem
 
 See the `examples` folder for examples.
 
+### Logging
+
+Default logging is to `STDOUT` with `DEBUG` level. Silence logger as follows.
+
+```ruby
+Wit.logger.level = Logger::WARN
+```
+
 ## API
 
 `wit-ruby` provides a Wit class with the following methods:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the `examples` folder for examples.
 
 ### Logging
 
-Default logging is to `STDOUT` with `DEBUG` level. Silence logger as follows.
+Default logging is to `STDOUT` with `INFO` level. Silence logger as follows.
 
 ```ruby
 Wit.logger.level = Logger::WARN

--- a/lib/wit.rb
+++ b/lib/wit.rb
@@ -88,28 +88,28 @@ class Wit
     if type == 'msg'
       raise WitException.new 'unknown action: say' unless @actions.has_key? :say
       msg = rst['msg']
-      logger.info("Executing say with: #{msg}")
+      logger.info "Executing say with: #{msg}"
       @actions[:say].call session_id, msg
     elsif type == 'merge'
       raise WitException.new 'unknown action: merge' unless @actions.has_key? :merge
-      logger.info('Executing merge')
+      logger.info 'Executing merge'
       context = @actions[:merge].call context, rst['entities']
       if context.nil?
-        logger.warn('missing context - did you forget to return it?')
+        logger.warn 'missing context - did you forget to return it?'
         context = {}
       end
     elsif type == 'action'
       action = rst['action'].to_sym
       raise WitException.new "unknown action: #{action}" unless @actions.has_key? action
-      logger.info("Executing action #{action}")
+      logger.info "Executing action #{action}"
       context = @actions[action].call context
       if context.nil?
-        logger.warn('missing context - did you forget to return it?')
+        logger.warn 'missing context - did you forget to return it?'
         context = {}
       end
     elsif type == 'error'
       raise WitException.new 'unknown action: error' unless @actions.has_key? :error
-      logger.info('Executing error')
+      logger.info 'Executing error'
       @actions[:error].call session_id, 'unknown action: error'
     else
       raise WitException.new "unknown type: #{type}"

--- a/lib/wit.rb
+++ b/lib/wit.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'logger'
 require 'net/http'
 
 WIT_API_HOST = ENV['WIT_URL'] || 'https://api.wit.ai'
@@ -42,9 +43,24 @@ def validate_actions(actions)
 end
 
 class Wit
+  class << self
+    attr_writer :logger
+
+    def logger
+      @logger ||= begin
+        $stdout.sync = true
+        Logger.new(STDOUT)
+      end
+    end
+  end
+
   def initialize(access_token, actions)
     @access_token = access_token
     @actions = validate_actions actions
+  end
+
+  def logger
+    self.class.logger
   end
 
   def message(msg)

--- a/lib/wit.rb
+++ b/lib/wit.rb
@@ -88,28 +88,28 @@ class Wit
     if type == 'msg'
       raise WitException.new 'unknown action: say' unless @actions.has_key? :say
       msg = rst['msg']
-      p "Executing say with: #{msg}"
+      logger.info("Executing say with: #{msg}")
       @actions[:say].call session_id, msg
     elsif type == 'merge'
       raise WitException.new 'unknown action: merge' unless @actions.has_key? :merge
-      p 'Executing merge'
+      logger.info('Executing merge')
       context = @actions[:merge].call context, rst['entities']
       if context.nil?
-        p 'WARN missing context - did you forget to return it?'
+        logger.warn('missing context - did you forget to return it?')
         context = {}
       end
     elsif type == 'action'
       action = rst['action'].to_sym
       raise WitException.new "unknown action: #{action}" unless @actions.has_key? action
-      p "Executing action #{action}"
+      logger.info("Executing action #{action}")
       context = @actions[action].call context
       if context.nil?
-        p 'WARN missing context - did you forget to return it?'
+        logger.warn('missing context - did you forget to return it?')
         context = {}
       end
     elsif type == 'error'
       raise WitException.new 'unknown action: error' unless @actions.has_key? :error
-      p 'Executing error'
+      logger.info('Executing error')
       @actions[:error].call session_id, 'unknown action: error'
     else
       raise WitException.new "unknown type: #{type}"

--- a/lib/wit.rb
+++ b/lib/wit.rb
@@ -50,7 +50,7 @@ class Wit
       @logger ||= begin
         $stdout.sync = true
         Logger.new(STDOUT)
-      end
+      end.tap { |logger| logger.level = Logger::INFO }
     end
   end
 


### PR DESCRIPTION
@patapizza, @martinraison, please review.

For many use cases other than local development, configurability for logging levels and/or format can be nice. This pull replaces usage of `p` statements w/ calls to a logger instance (defaults to one from stdlib).
