### PR TITLE
Add on_converse_response and on_message_response callbacks, defaults …

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ p "Yay, got Wit.ai response: #{resp}"
 
 See the [docs](https://wit.ai/docs) for more information.
 
+### Callbacks
+
+Support custom callbacks upon receiving responses from the message and converse APIs. These default to logging them at debug level. This can also be overwritten.
+
+Example:
+```ruby
+Wit.on_converse_response = ->(res) { puts "Converse confidence: #{res['confidence']}" }
+```
 
 ## Thanks
 

--- a/lib/wit.rb
+++ b/lib/wit.rb
@@ -46,13 +46,21 @@ end
 
 class Wit
   class << self
-    attr_writer :logger
+    attr_writer :logger, :on_converse_response, :on_message_response
 
     def logger
       @logger ||= begin
         $stdout.sync = true
         Logger.new(STDOUT)
       end.tap { |logger| logger.level = Logger::INFO }
+    end
+
+    def on_converse_response
+      @on_converse_response ||= ->(res) { logger.debug "Converse response: #{res}" }
+    end
+
+    def on_message_response
+      @on_message_response ||= ->(res) { logger.debug "Message response: #{res}" }
     end
   end
 
@@ -70,7 +78,7 @@ class Wit
     params = {}
     params[:q] = msg unless msg.nil?
     res = req @access_token, Net::HTTP::Get, '/message', params
-    logger.debug "Message response: #{res}"
+    self.class.on_message_response.call(res)
     return res
   end
 
@@ -81,7 +89,7 @@ class Wit
     params[:q] = msg unless msg.nil?
     params[:session_id] = session_id
     res = req @access_token, Net::HTTP::Post, '/converse', params, context
-    logger.debug "Converse response: #{res}"
+    self.class.on_converse_response.call(res)
     return res
   end
 


### PR DESCRIPTION
…to debug logging

@patapizza, @martinraison, please review.

It may be useful to have some custom behavior based off of the responses from `message` or `converse` API while still using the `run_actions` API (otherwise, customization results in replicating a lot of the same logic).

This pull adds callbacks which can be overwritten. They default to debug logging for backwards compatibility.
