### PR TITLE
Allow actions to work as long as they support #call and #arity instea…

### DIFF
--- a/lib/wit.rb
+++ b/lib/wit.rb
@@ -35,7 +35,7 @@ def validate_actions(actions)
   end
   actions.each_pair do |k, v|
     raise WitException.new "The '#{k}' action name should be a symbol" unless k.is_a? Symbol
-    raise WitException.new "The '#{k}' action should be a lambda function" unless v.respond_to? :call and v.lambda?
+    raise WitException.new "The '#{k}' action should respond to call and arity" unless v.respond_to? :call and v.respond_to? :arity
     raise WitException.new "The \'say\' action should take 3 arguments: session_id, context, msg. #{learn_more}" if k == :say and v.arity != 3
     raise WitException.new "The \'merge\' action should take 4 arguments: session_id, context, entities, msg. #{learn_more}" if k == :merge and v.arity != 4
     raise WitException.new "The \'error\' action should take 3 arguments: session_id, context, error. #{learn_more}" if k == :error and v.arity != 3


### PR DESCRIPTION
…d of forcing them to be lamdbas

@patapizza, @martinraison, please review.

In the Ruby spirit of duck typing, it might be useful to allow actions to be any object.

For code organization purposes, I've found it useful to define classes like these.

``` ruby
class BaseAction
  class << self
    def inherited(klass)
      @subclasses ||= []
      @subclasses << klass
    end

    def actions
      @actions ||= Hash[@subclasses.map { |c| [c.symbol, c] }]
    end

    def arity
      method(:call).arity
    end

    def call(session_id, context)
      context
    end
  end
end

class CustomAction < BaseAction
  class << self
    def symbol
      :custom
    end

    def call(session_id, context)
      # do stuff
      context
    end
  end
end
```

If the lambda isn't enforced, I can just pass `BaseActions.actions` into actions. While we can also implement a `#lambda?` on the custom class above, that feels like an unnecessary constraint if all the caller needs is `#call` and `#arity`
