### PR TITLE
QuickStart "Where?" fix

### DIFF
--- a/examples/quickstart.rb
+++ b/examples/quickstart.rb
@@ -29,6 +29,7 @@ actions = {
     loc = first_entity_value(entities, 'location')
     if loc
         context['forecast'] = 'sunny'
+        context.delete('missingLocation')
     else
         context['missingLocation'] = true
         context.delete('forecast')


### PR DESCRIPTION
Fixed an issue when working through the quick start tutorial that the
‘Where?’ question is repeatedly asked regardless of response.
