### PR TITLE
Idiomatic Ruby Cleanups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 - Renamed WitException to Wit::Error
 - Changed Wit::Error to inherit from StandardError instead of Exception
 - Moved constants inside Wit namespace
+- Moved #req and #validate_actions to private methods within Wit namespace
 
 ## v4.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## development
 - Renamed WitException to Wit::Error
 - Changed Wit::Error to inherit from StandardError instead of Exception
+- Moved constants inside Wit namespace
 
 ## v4.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## development
+- Renamed WitException to Wit::Error
+- Changed Wit::Error to inherit from StandardError instead of Exception
+
 ## v4.1.0
 
 - `converse` now takes `reset` as optional parameter.

--- a/lib/wit.rb
+++ b/lib/wit.rb
@@ -3,11 +3,6 @@ require 'logger'
 require 'net/http'
 require 'securerandom'
 
-WIT_API_HOST = ENV['WIT_URL'] || 'https://api.wit.ai'
-WIT_API_VERSION = ENV['WIT_API_VERSION']  || '20160516'
-DEFAULT_MAX_STEPS = 5
-LEARN_MORE = 'Learn more at https://wit.ai/docs/quickstart'
-
 def req(logger, access_token, meth_class, path, params={}, payload={})
   uri = URI(WIT_API_HOST + path)
   uri.query = URI.encode_www_form(params)
@@ -59,6 +54,11 @@ end
 
 class Wit
   class Error < StandardError; end
+
+  WIT_API_HOST = ENV['WIT_URL'] || 'https://api.wit.ai'
+  WIT_API_VERSION = ENV['WIT_API_VERSION']  || '20160516'
+  DEFAULT_MAX_STEPS = 5
+  LEARN_MORE = 'Learn more at https://wit.ai/docs/quickstart'
 
   def initialize(opts = {})
     @access_token = opts[:access_token]

--- a/wit.gemspec
+++ b/wit.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'wit'
-  s.version = '4.1.0'
+  s.version = '5.0.0'
   s.date = Date.today.to_s
   s.summary = 'Ruby SDK for Wit.ai'
   s.description = 'Ruby SDK for Wit.ai'


### PR DESCRIPTION
This PR cleans up several things in the library to make it integrate better with existing apps:
- Renamed WitException to Wit::Error
- Changed Wit::Error to [inherit from StandardError instead of Exception](http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby#10048406)
- Moved constants inside Wit namespace
- Moved `#req` and `#validate_actions` to private methods within Wit namespace

Because of the exception name change, a major version bump will be required to follow SemVer.

I made `#req` and `#validate_actions` private because I don't think they are intentionally part of the public API. I can change this if I inferred incorrectly.
