### PR TITLE
reset on new messages and errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+- `converse` now takes `reset` as optional parameter.
+
+### Breaking changes
+
+- `run_actions` now resets the last turn on new messages and errors.
+
 ## v4.0.0
 
 After a lot of internal dogfooding and bot building, we decided to change the API in a backwards-incompatible way. The changes are described below and aim to simplify user code and accommodate upcoming features.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ puts("Yay, got Wit.ai response: #{rsp}")
 ### .run_actions()
 
 A higher-level method to the Wit converse API.
+`run_actions` resets the last turn on new messages and errors.
 
 Takes the following parameters:
 * `session_id` - a unique identifier describing the user session
@@ -102,6 +103,7 @@ Takes the following parameters:
 * `session_id` - a unique identifier describing the user session
 * `msg` - the text received from the user
 * `context` - the `Hash` representing the session state
+* `reset` - (optional) whether to reset the last turn
 
 Example:
 ```ruby

--- a/lib/wit.rb
+++ b/lib/wit.rb
@@ -175,7 +175,10 @@ class Wit
     # Each new call increments an index for the session.
     # We only care about the last call to run_actions.
     # All the previous ones are discarded (preemptive exit).
-    current_request = if @_sessions.has_key?(session_id) then @_sessions[session_id] + 1 else 1 end
+    current_request = 1
+    if @_sessions.has_key?(session_id)
+      current_request = @_sessions[session_id] + 1
+    end
     @_sessions[session_id] = current_request
 
     context = __run_actions(session_id, current_request, message, context, max_steps)


### PR DESCRIPTION
- `converse` to take `reset` as optional parameter
- `run_actions` now resets on new messages and errors
