### PR TITLE
Force interactive to use STDIN.gets

### DIFF
--- a/lib/wit.rb
+++ b/lib/wit.rb
@@ -199,7 +199,7 @@ class Wit
     session_id = SecureRandom.uuid
     while true
       print '> '
-      msg = gets.strip
+      msg = STDIN.gets.strip
       if msg == ''
         next
       end


### PR DESCRIPTION
This fixes a problem where calling Wit#interactive within, for example, a rake task, leads to an error because Kernel#gets is invoked instead of STDIN#gets.
