### PR TITLE
[Fix] validate_payload for keyword and synonyms

### DIFF
--- a/lib/wit.rb
+++ b/lib/wit.rb
@@ -170,6 +170,8 @@ class Wit
       roles: Array,
       lookups: Array,
       keywords: Array,
+      keyword: String,
+      synonyms: Array,
       text: String,
       intent: String,
       entities: Array,


### PR DESCRIPTION
### Problem
- I can't use `post_entities_keywords` method to Add a new keyword for the entity.

### Action
- Fix the `validate_payload` to check key type for `keyword` and `synonyms`